### PR TITLE
Fix run task for files in subfolders—splitext bug

### DIFF
--- a/TeX.novaextension/Scripts/main.js
+++ b/TeX.novaextension/Scripts/main.js
@@ -162,7 +162,7 @@ class LatexTaskProvider {
 		if (context.action == Task.Build) {
 			return LatexTaskProvider.latexmkTask(...options, mainfile);
 		} else if (context.action == Task.Run) {
-			return displayLine(nova.path.splitext(mainfile)[0] + ".pdf");
+			return displayLine(nova.path.join(nova.path.dirname(mainfile), nova.path.splitext(mainfile)[0]) + ".pdf");
 		} else if (context.action == Task.Clean) {
 			return LatexTaskProvider.latexmkTask("-c", mainfile);
 		}
@@ -274,7 +274,7 @@ class ContextTaskProvider {
 		if (context.action == Task.Build) {
 			return ContextTaskProvider.contextTask("--synctex", mainfile);
 		} else if (context.action == Task.Run) {
-			return displayLine(nova.path.splitext(mainfile)[0] + ".pdf");
+			return displayLine(nova.path.join(nova.path.dirname(mainfile), nova.path.splitext(mainfile)[0]) + ".pdf");
 		}
 	}
 }


### PR DESCRIPTION
This wasn’t working if the main file is not in the workspace folder. The problem is that `nova.path.splitext` doesn’t do what [they say it does](https://docs.nova.app/api-reference/path/#splitextpath), but instead throws away the path. I ran into this problem developing my extension, and that’s the reason for the `$FileDirname` [here](https://github.com/flyx/TeX.novaextension/blob/dc0cad8d84c90a6d485b4f386995a1a09e8b966b/TeX.novaextension/Scripts/main.js#L88).